### PR TITLE
docs(2-Install-Activate): zygisk support

### DIFF
--- a/2-Install-Activate.md
+++ b/2-Install-Activate.md
@@ -39,7 +39,7 @@ Thanox中大部分的功能都是在系统进程中完成的，因此Thanox会�
 ### Magisk模式(实验)
 
 1. 你的设备必须已经正确安装了**Magisk框架**
-2. 你的设备必须已经正确安装了**riru**框架
+2. 你的设备必须已经正确安装了**Riru框架**（Magisk v23+）或者启用了**Zygisk模式**（Magisk v24+）
 3. 安装最新Thanox 应用
 4. 点击Thaox设置--关于--补丁状态，导出magisk补丁；或者直接将thanox apk重命名为.zip格式即为magisk补丁
 5. 刷入上个步骤获取到的magisk补丁


### PR DESCRIPTION
经过我自己的实操以及浏览数个 GitHub Issue（#343 #394 ），现在的 Thanox 已经可以被认定支持 Zigisk API 了。可能相较于 Xposed 模式确实还有些许问题，但是本来在文档中就已经提醒 Magisk 模式是实验性的，我认为这样表达并无不妥。

基于以上考虑，我尝试更改了文档中的相关描述。