### PR TITLE
fix: statically link zygisk module libc++

### DIFF
--- a/android/android_framework/patch-magisk/module/build.gradle.kts
+++ b/android/android_framework/patch-magisk/module/build.gradle.kts
@@ -30,7 +30,10 @@ android {
         externalNativeBuild {
             cmake {
                 cppFlags.add("-std=c++17 -fno-exceptions -fno-rtti -fvisibility=hidden -fvisibility-inlines-hidden")
-                arguments("-DMODULE_NAME:STRING=${tornaco.project.android.thanox.MagiskModConfigs.moduleLibraryName}")
+                arguments(
+                    "-DMODULE_NAME:STRING=${tornaco.project.android.thanox.MagiskModConfigs.moduleLibraryName}",
+                    "-DANDROID_STL=c++_static",
+                )
             }
         }
     }

--- a/android/android_framework/patch-magisk/module/src/main/cpp/CMakeLists.txt
+++ b/android/android_framework/patch-magisk/module/src/main/cpp/CMakeLists.txt
@@ -16,5 +16,5 @@ set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${LINKER_FLAGS}")
 
 add_library(${MODULE_NAME} SHARED core/ThanoxBridge.cpp zygisk/thanox.cpp)
 
-target_link_libraries(${MODULE_NAME} log)
+target_link_libraries(${MODULE_NAME} log c++_static)
 set_target_properties(${MODULE_NAME} PROPERTIES LINK_FLAGS_RELEASE -s)


### PR DESCRIPTION
$Summary:\n- force the patch-magisk zygisk module to build with `c++_static`\n- link `c++_static` explicitly in the native module target\n\nWhy:\nThe built `zygisk_thanox` binary currently depends on `libc++_shared.so`, but the installed Magisk module only ships the ABI entry `.so`. On-device this causes the current cold-boot loader failure: `dlopen ... libc++_shared.so not found`.